### PR TITLE
Add transferables support

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -159,27 +159,33 @@ export function getTargetHost(): any {
  * @param target The target to send the message to
  * @param message The message to send
  * @param origin Optional origin for iframe communication
+ * @param transferables Optional transferables for postMessage
  */
-export function postMessageToTarget(target: Target, message: any, origin?: string): void {
+export function postMessageToTarget(
+  target: Target,
+  message: any,
+  origin?: string,
+  transferables?: Transferable[],
+): void {
   if (!target) {
     throw new Error("Rimless Error: No target specified for postMessage");
   }
 
   // Node.js Worker
   if (isNodeEnv() && target === parentPort) {
-    target.postMessage(JSON.parse(JSON.stringify(message)));
+    target.postMessage(message, { transfer: transferables });
     return;
   }
 
   // Web Worker
   if (isWorker()) {
-    target.postMessage(JSON.parse(JSON.stringify(message)));
+    target.postMessage(message, { transfer: transferables });
     return;
   }
 
   // iframe or window
   if (target.postMessage) {
-    target.postMessage(JSON.parse(JSON.stringify(message)), { targetOrigin: origin || "*" });
+    target.postMessage(message, { targetOrigin: origin || "*", transfer: transferables });
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import guest from "./guest";
 import host from "./host";
+import { withTransferable } from "./rpc";
 
-export { host, guest };
+export { host, guest, withTransferable };
 
 export * from "./types";


### PR DESCRIPTION
This PR introduces support for transferable objects over rimless' APIs.

Setting a separate PR so we can merge and publish with this change without gating on upstream adoption.