### PR TITLE
ci: fix labeled-PR release path so npm publish actually fires

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,11 +11,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # Only run for non-draft versions
+    # When invoked via `workflow_call`, `github.event_name` reflects the
+    # ROOT triggering event of the caller (e.g. `pull_request`), NOT
+    # `workflow_call` — so a `== 'workflow_call'` check never matches.
+    # Trust the caller's own gating in that case; only re-check
+    # draft/tag-prefix when fired directly by a `release` event.
     if: |
-      github.event_name == 'workflow_call' ||
-      (github.event_name == 'release' &&
-       github.event.release.draft == false &&
+      github.event_name != 'release' ||
+      (github.event.release.draft == false &&
        startsWith(github.event.release.tag_name, 'v'))
     steps:
       - name: Checkout

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -67,10 +67,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Use the app token (not the default GITHUB_TOKEN) so the resulting
+      # `release: [published]` event can trigger downstream workflows
+      # (e.g. npm-publish.yml directly). Events fired by GITHUB_TOKEN
+      # do not trigger other workflows — see
+      # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+      # The publish chain here already routes around this via workflow_call,
+      # but using the app token keeps the release path symmetric and lets a
+      # human re-cut a release without breaking the npm publish.
       - name: Create a GitHub Release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         with:
           tag_name: v${{ steps.bump-version.outputs.new_version }}
           release_name: v${{ steps.bump-version.outputs.new_version }}


### PR DESCRIPTION
## Summary

Two bugs in the publish chain caused PR #12 (the release-trigger for `0.6.4`) to bump `package.json`, tag, and create the GitHub Release — but silently skip the npm publish step.

### Bug 1: `npm-publish.yml` gated on `event_name == 'workflow_call'`

When a reusable workflow is invoked via `workflow_call`, `github.event_name` reflects the **root triggering event** of the caller (in our case `pull_request`), not the literal string `'workflow_call'`. The condition never matched, the build job was marked _skipped_, and `npm publish` never ran. Replaced with `event_name != 'release'` — trust the caller's own gating when called as a sub-workflow; only re-check `draft` / tag-prefix when fired directly by a release event.

### Bug 2: `actions/create-release@v1` used default `GITHUB_TOKEN`

Per GitHub's security model, events emitted by `GITHUB_TOKEN` do **not** trigger downstream workflows. So even if someone created a release expecting the `release: [published]` event to fire `npm-publish.yml`, nothing happened. Swapped to the app token already configured earlier in the same job (`steps.app-token.outputs.token`), restoring the release path as a viable backup trigger.

## Recovery plan for 0.6.4

`package.json` is at `0.6.4` on master, tag `v0.6.4` exists, GitHub Release `v0.6.4` exists — but npm registry is still at `0.6.3`. After this PR merges, recreate the `v0.6.4` GitHub Release from a human/app token (e.g. `gh release delete v0.6.4 --cleanup-tag=false && gh release create v0.6.4 --target master --title v0.6.4 --notes "..."`). The new `release: [published]` event will fire `npm-publish.yml`, which now passes the `if` and publishes `0.6.4` to npm. The tag stays the same, so no version churn.

## Test plan

- [x] `actionlint` / `yaml` syntactically valid
- [ ] Merge → manually recreate `v0.6.4` release → confirm `Publish to NPM` run completes → `npm view @jam.dev/rimless version` returns `0.6.4`
- [ ] Future labeled-PR releases publish without manual intervention