### PR TITLE
ci: switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,12 +5,15 @@ on:
     types: [published]
   # or it is called by another workflow
   workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Required for npm Trusted Publishing (OIDC). Without `id-token: write`
+    # GitHub will not mint the OIDC token that npm exchanges for a
+    # short-lived publish credential.
+    permissions:
+      id-token: write
+      contents: read
     # When invoked via `workflow_call`, `github.event_name` reflects the
     # ROOT triggering event of the caller (e.g. `pull_request`), NOT
     # `workflow_call` — so a `== 'workflow_call'` check never matches.
@@ -24,13 +27,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: npm ci
       - name: Publish package on NPM
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -90,5 +90,8 @@ jobs:
   publish-package:
     needs: publish-release
     uses: ./.github/workflows/npm-publish.yml
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+    # npm Trusted Publishing (OIDC) — no NPM_TOKEN secret needed.
+    # The called workflow declares `permissions: id-token: write` itself.
+    permissions:
+      id-token: write
+      contents: read


### PR DESCRIPTION
## Summary

Replaces the `NPM_TOKEN` secret with npm's [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) so CI no longer fails on the 2FA OTP prompt that blocked the last `@jam.dev/rimless@0.6.4` publish. Adds `id-token: write` to both `npm-publish.yml` and the `publish-release.yml` caller, bumps `setup-node` to v4 and Node to 22 (needed for npm >= 11.5.1, which performs the OIDC exchange), and drops `NODE_AUTH_TOKEN`.

## Prerequisite before merging

Configure a trusted publisher on npmjs.com for `@jam.dev/rimless` pointing at: org `jamdotdev`, repo `rimless`, workflow filename `npm-publish.yml`, action `npm publish`. Without this, the next publish will fail with an auth error. Once the publish path is verified working, the `NPM_TOKEN` repo secret can be deleted.

## Test plan

- [ ] Trusted publisher entry added on npmjs.com before merge
- [ ] Merge a PR labeled `release:patch` and confirm `publish-package` job succeeds without `NPM_TOKEN`
- [ ] Confirm the published version shows a provenance attestation on npmjs.com