### PR TITLE
ci: align npm publish workflow with npm OIDC docs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -25,11 +25,11 @@ jobs:
        startsWith(github.event.release.tag_name, 'v'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary
- Bump \`actions/checkout\` and \`actions/setup-node\` to \`@v6\` to match the npm Trusted Publishing docs example.
- Bump \`node-version\` from 22 to 24 so the runner ships npm >= 11.5.1, which is required for npm's OIDC publish exchange. Under Node 22 the publish was falling back to anonymous and the registry returned a misleading \`404 Not Found\` for \`@jam.dev/rimless\`.

## Test plan
- [ ] Cut a patch release and confirm \`npm publish\` succeeds via OIDC (no \`NPM_TOKEN\` secret used).